### PR TITLE
Add notifications for auth success and error

### DIFF
--- a/app/routes/auth/login.js
+++ b/app/routes/auth/login.js
@@ -4,13 +4,31 @@ const { Route, inject } = Ember;
 
 export default Route.extend({
   session: inject.service(),
+  notify: inject.service(),
+
   actions: {
     doLogin() {
       let user = this.get('currentModel');
       this.get('session')
         .authenticate(
           'authenticator:reverie', user.email, user.password
-        );
+        ).then(() => {
+          // Success
+          this.get('notify').success('Logged In!');
+        }).catch((response) => {
+          let { errors } = response;
+
+          // Check if there's a 401
+          if (errors.mapBy('code').indexOf(401) >= 0) {
+            // Flash Unauthorized
+            this.get('notify')
+              .error('Incorrect username or password, please try again');
+          } else {
+            // Other API errors
+            this.get('notify')
+              .error('There was a Server Error, please try again later');
+          }
+        });
     }
   },
   model() {

--- a/app/routes/auth/register.js
+++ b/app/routes/auth/register.js
@@ -1,13 +1,20 @@
 import Ember from 'ember';
 
-const { Route } = Ember;
+const { Route, inject } = Ember;
 
 export default Route.extend({
+  notify: inject.service(),
   actions: {
     doRegister() {
       this.get('currentModel').save()
         .then(() => {
+          // Successfully saved
           this.transitionTo('auth.login');
+          this.get('notify').success('Registered! Please log in now :)');
+        })
+        .catch((resp) => {
+          let { errors } = resp;
+          this.get('notify').error(errors.mapBy('detail').join(', '));
         });
     }
   },

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -3,6 +3,15 @@
 }
 
 .ember-notify-default .ember-notify {
-  border-color: rgb(150, 204, 255);
-  border-width: .125rem;
+  border: none;
+}
+
+.ember-notify-default .info {
+  background-color: rgb(150, 204, 255);
+}
+.ember-notify-default .success {
+  background-color: #578F88;
+}
+.ember-notify-default .error {
+  background-color: #B05746;
 }

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -4,6 +4,7 @@
 
 .ember-notify-default .ember-notify {
   border: none;
+  padding: 1rem;
 }
 
 .ember-notify-default .info {

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -1,6 +1,6 @@
-{{#ember-notify as |message close|}}
-  <a {{action close}} class='close red'>x</a>
-  <span class='message-from-block black-80'>{{message.text}}</span>
+{{#ember-notify closeAfter=4000 as |message close|}}
+  <a {{action close}} class='close black-60'>x</a>
+  <span class='message-from-block white'>{{message.text}}</span>
 {{/ember-notify}}
 
 <header class="bg-white black-80 tc pv4 avenir">

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -1,4 +1,4 @@
-{{#ember-notify closeAfter=4000 as |message close|}}
+{{#ember-notify closeAfter=5000 as |message close|}}
   <a {{action close}} class='close black-60'>x</a>
   <span class='message-from-block white'>{{message.text}}</span>
 {{/ember-notify}}

--- a/app/utils/user-validations.js
+++ b/app/utils/user-validations.js
@@ -8,7 +8,7 @@ export const email = [
 export const password = [
   validator('presence', true),
   validator('length', {
-    min: 4,
+    min: 8,
     max: 24
   })
 ];

--- a/config/environment.js
+++ b/config/environment.js
@@ -74,7 +74,8 @@ module.exports = function(environment) {
   // Default ember-pouch config for dev
   ENV.emberPouch = {
     localDb: 'local_pouch',
-    remoteDb: 'http://localhost:5984/offline'
+    remoteDb: ''
+    // remoteDb: 'http://localhost:5984/offline'
   };
 
   if (environment === 'production') {


### PR DESCRIPTION
This chains off the promises and kicks of a notification depending on success/the kind of error.
Uses the ember-notify service throughout.

Might be worthwhile to switch to ember-concurrency- backed tasks in the future.