### PR TITLE
Handle Stickers Offline Case

### DIFF
--- a/app/components/sticker-card.js
+++ b/app/components/sticker-card.js
@@ -15,6 +15,7 @@ export default Component.extend(Validations, {
   notify: inject.service(),
   session: inject.service(),
   store: inject.service(),
+  connection: inject.service(),
 
   sendSticker: task(function* () {
     // Get the "new sticker" model

--- a/app/controllers/app/stickers/show.js
+++ b/app/controllers/app/stickers/show.js
@@ -9,17 +9,34 @@ export default Controller.extend({
   store: inject.service(),
 
   nextSticker: task(function* (advanceBy = 1) {
-    let stickers = yield this.get('session').currentUser.get('stickers');
+    // Deprecated while CORS HSTS redirect is an issue
+    // let stickers = yield this.get('session').currentUser.get('stickers');
+
+    // let uid = yield this.get('session').currentUser.id;
+    // eslint-disable-next-line camelcase
+    // let stickers = yield this.store.query('sticker', {user_id: uid, include: 'sender,categories'});
+
+    let stickers = yield this.get('store').peekAll('sticker');
+
     let current = stickers.indexOf(this.get('model'));
 
     let next = current;
-    let max = stickers.length;
+    let max = stickers.get('length');
 
     // Cycle through the array forward or backward
     if (advanceBy > 0) {
       next = (current + advanceBy) % max;
     } else {
       next = (max + ((current + advanceBy) % max)) % max;
+    }
+
+    if (next === 0 || next === max - 1) {
+      let uid = yield this.get('session').currentUser.id;
+      yield this.get('store').query('sticker', {
+      // eslint-disable-next-line camelcase
+        user_id: uid,
+        include: 'sender,categories'
+      });
     }
 
     let nextSticker = stickers.objectAt(next);

--- a/app/routes/app/stickers/index.js
+++ b/app/routes/app/stickers/index.js
@@ -9,11 +9,16 @@ export default Route.extend({
     // Used with the explicit query below, if enabled
     let uid = this.get('session').currentUser.id;
     return RSVP.hash({
+      // --- Option 1 ---
       // A downside of this approach is that the data is not linked to the
       // user's model, but makes sideloading explicit.
-      // eslint-disable-next-line camelcase
-      stickers: this.store.query('sticker', {user_id: uid, include: 'sender,categories'}),
+      stickers: this.store.query('sticker', {
+        // eslint-disable-next-line camelcase
+        user_id: uid,
+        include: 'sender,categories'
+      }),
 
+      // --- Option 2 ---
       // A bit "magical", as Ember-data handles loading the async relationship
       // via GET at /users/:id/stickers. Note that this method does not allow
       // for explicit sideloading atm. The API currently always sideloads
@@ -23,6 +28,7 @@ export default Route.extend({
       // stickers in the model, which does not happen with store.query.
       // stickers: this.get('session').currentUser.get('stickers', {include: 'sender'}),
 
+      // --- Categories ---
       // It is important to have the categories available, even if the user
       // has not been awarded all of them (thus not included in query above)
       categories: this.store.findAll('category')

--- a/app/services/connection.js
+++ b/app/services/connection.js
@@ -2,7 +2,7 @@ import Ember from 'ember';
 
 const {
   computed: { equal },
-  Logger: { debug },
+  // Logger: { debug },
   set,
   Service
 } = Ember;
@@ -16,11 +16,11 @@ export default Service.extend({
     this._super(...arguments);
     set(this, 'state', window.navigator.onLine ? 'online' : 'offline');
     this._onOfflineHandler = () => {
-      debug('Connection State: offline');
+      // debug('Connection State: offline');
       set(this, 'state', 'offline');
     };
     this._onOnlineHandler = () => {
-      debug('Connection State: online');
+      // debug('Connection State: online');
       set(this, 'state', 'online');
     };
 

--- a/app/services/connection.js
+++ b/app/services/connection.js
@@ -1,0 +1,36 @@
+import Ember from 'ember';
+
+const {
+  computed: { equal },
+  Logger: { debug },
+  set,
+  Service
+} = Ember;
+
+export default Service.extend({
+  state: 'offline',
+  isOnline: equal('state', 'online'),
+  isOffline: equal('state', 'offline'),
+
+  init() {
+    this._super(...arguments);
+    set(this, 'state', window.navigator.onLine ? 'online' : 'offline');
+    this._onOfflineHandler = () => {
+      debug('Connection State: offline');
+      set(this, 'state', 'offline');
+    };
+    this._onOnlineHandler = () => {
+      debug('Connection State: online');
+      set(this, 'state', 'online');
+    };
+
+    window.addEventListener('offline', this._onOfflineHandler);
+    window.addEventListener('online', this._onOnlineHandler);
+  },
+
+  destroy() {
+    window.removeEventListener('offline', this._onOfflineHandler);
+    window.removeEventListener('online', this._onOnlineHandler);
+    this._super(...arguments);
+  }
+});

--- a/app/templates/components/rev-input.hbs
+++ b/app/templates/components/rev-input.hbs
@@ -9,6 +9,7 @@
 </div>
 
 <input type="{{type}}"
+  disabled={{disabled}}
   value="{{value}}"
   class="input-reset db mb2 pa2 w-100 ba bw1 b--black-20
   {{if value

--- a/app/templates/components/rev-textarea.hbs
+++ b/app/templates/components/rev-textarea.hbs
@@ -10,6 +10,7 @@
 
 <textarea
   rows="{{rows}}"
+  disabled={{disabled}}
   class="input-reset db mb2 pa2 w-100 ba bw1 b--black-20
   {{if value
     (concat

--- a/app/templates/components/sticker-card.hbs
+++ b/app/templates/components/sticker-card.hbs
@@ -4,55 +4,70 @@
   buttonText='Send Sticker'
   buttonDisabled=validations.messages.length
 }}
-  <div class="mb3">
-    {{rev-input
-      value=model.newSticker.receiver
-      errors=(v-get this 'model.newSticker.receiver' 'messages')
-      classNames=''
-      type='email'
-      label='Receiver email*'}}
-  </div>
-
-  <div class="mb4">
-    <div class="mb2">
-      <label class="db mb1 f6 b"
-        data-error={{_errorMessages}}>
-        Sticker type*
-      </label>
-    </div>
-    {{#power-select
-      searchEnabled=false
-      options=model.categories
-      selected=model.newSticker.category
-      onchange=(action (mut model.newSticker.category))
-      as |category|
-    }}
-    <img src="{{category.imgurl}}" class="dib h1 w1"> <strong>{{category.title}}</strong>
-    {{/power-select}}
-  </div>
-
-  <div class="mb4">
-    {{#rev-textarea
-      rows=4
-      value=model.newSticker.title
-      errors=(v-get this 'model.newSticker.title' 'messages')
-      classNames=''
-      searchEnabled=false
-      label='Message'}}
-      <span class="fw5">
-        (Optional; 150 characters max)
-      </span>
-    {{/rev-textarea}}
-    <div class="db tr">
-      <span class="f6">{{model.newSticker.title.length}}/150 Chars</span>
-    </div>
-  </div>
-
-  {{#if model.newSticker.errors}}
-    <div class="mb3">
-      {{#each model.newSticker.errors as |error|}}
-        <span class="db red mb2">{{error}}</span>
-      {{/each}}
+  {{#if connection.isOffline}}
+    <div class="row mb3 ph3">
+      <div class="w-100 pa3 tc bg-light-red white">
+        <p class="center f6">
+          You are currently offline, so you cannot send stickers :(
+        </p>
+      </div>
     </div>
   {{/if}}
+
+  <div class="{{if connection.isOffline "o-50"}}">
+    <div class="mb3">
+      {{rev-input
+        value=model.newSticker.receiver
+        errors=(v-get this 'model.newSticker.receiver' 'messages')
+        classNames=''
+        type='email'
+        label='Receiver email*'
+        disabled=connection.isOffline}}
+    </div>
+
+    <div class="mb4">
+      <div class="mb2">
+        <label class="db mb1 f6 b"
+          data-error={{_errorMessages}}>
+          Sticker type*
+        </label>
+      </div>
+      {{#power-select
+        searchEnabled=false
+        disabled=connection.isOffline
+        options=model.categories
+        selected=model.newSticker.category
+        onchange=(action (mut model.newSticker.category))
+        as |category|
+      }}
+      <img src="{{category.imgurl}}" class="dib h1 w1"> <strong>{{category.title}}</strong>
+      {{/power-select}}
+    </div>
+
+    <div class="mb4">
+      {{#rev-textarea
+        rows=4
+        value=model.newSticker.title
+        errors=(v-get this 'model.newSticker.title' 'messages')
+        classNames=''
+        searchEnabled=false
+        disabled=connection.isOffline
+        label='Message'}}
+        <span class="fw5">
+          (Optional; 150 characters max)
+        </span>
+      {{/rev-textarea}}
+      <div class="db tr">
+        <span class="f6">{{model.newSticker.title.length}}/150 Chars</span>
+      </div>
+    </div>
+
+    {{#if model.newSticker.errors}}
+      <div class="mb3">
+        {{#each model.newSticker.errors as |error|}}
+          <span class="db red mb2">{{error}}</span>
+        {{/each}}
+      </div>
+    {{/if}}
+  </div>
 {{/rev-card}}

--- a/config/environment.js
+++ b/config/environment.js
@@ -42,7 +42,31 @@ module.exports = function(environment) {
   };
 
   ENV.serviceWorker = {
-    excludePaths: ['index.html', 'manifest.appcache']
+    enabled: true,
+    excludePaths: ['index.html', 'manifest.appcache'],
+    networkFirstURLs: [
+      {
+        route: '/api/stickers',
+        method: 'any',
+        options: {
+          origin: 'https://safe-brushlands-58823.herokuapp.com'
+        }
+      },
+      {
+        route: '/api/users/current',
+        method: 'any',
+        options: {
+          origin: 'https://safe-brushlands-58823.herokuapp.com'
+        }
+      },
+      {
+        route: '/api/categories/',
+        method: 'any',
+        options: {
+          origin: 'https://safe-brushlands-58823.herokuapp.com'
+        }
+      }
+    ]
     // swIncludeFiles: [
     //   'node_modules/pouchdb/dist/pouchdb.js'
     // ]
@@ -54,7 +78,7 @@ module.exports = function(environment) {
     // ENV.APP.LOG_TRANSITIONS = true;
     // ENV.APP.LOG_TRANSITIONS_INTERNAL = true;
     // ENV.APP.LOG_VIEW_LOOKUPS = true;
-    ENV.serviceWorker.enabled = false;
+    // ENV.serviceWorker.enabled = false;
     ENV.serviceWorker.debug = true;
   }
 

--- a/notes/offline_stickers.md
+++ b/notes/offline_stickers.md
@@ -1,0 +1,28 @@
+# CORS issue
+Disallows easy association, which means the store is not very useful for global state
+
+# When to update
+Cycling behaviour
+
+Sticker index always reloads?
+And then only store.peek('sticker') and filter that?
+  What if someone visits /app/stickers/:id directly?
+    Cycling wouldn't work
+    So maybe we should reload every time
+    Or when reaching start/end off cycle array?
+
+# Where to place the cache/update behaviour
+Ember or Service worker?
+
+Ember peek as above OR
+Background reload
+  That is fiddly due to the CORS issue atm, so can't use currentUser object
+
+Service worker:
+"Fastest" strategy
+  Always makes a request, not ideal for power
+  But it is pretty fast
+
+Separate service?
+Which keeps the user state and is updated via peek?
+

--- a/tests/unit/services/connection-test.js
+++ b/tests/unit/services/connection-test.js
@@ -1,0 +1,12 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('service:connection', 'Unit | Service | connection', {
+  // Specify the other units that are required for this test.
+  // needs: ['service:foo']
+});
+
+// Replace this with your real tests.
+test('it exists', function(assert) {
+  let service = this.subject();
+  assert.ok(service);
+});

--- a/worklog.md
+++ b/worklog.md
@@ -1,9 +1,10 @@
 # Next Feature:
-- Sticker export
+- Prefetch strategy for relevant sticker requests?
+- "Offline" service https://tsubik.com/blog/make-your-emberjs-web-app-more-progressive-part-3-offline-data/
+  - Use offline service to prevent sticker sending
 
 # Priority
-- User stickers CORS/OPTIONS redirect bug
-  - Happens when using Ember data .get('stickers'), but not .query(...)
+- Sticker export
 - Note overhaul fields,
   - Note card interface overhaul
   - Import/Export notes
@@ -14,17 +15,19 @@
 - "Timeline view"
 
 # Visual / UX:
+- Animations for routes, stickers
+- Model hook loading spinner
 - Menus
   - Flexbox
   - Color-code logged-in/out items
   - Log-in, log-out spot on menu
     - log-in task failure message
   - Sticker send-received submenu
+- Color unification
 
 - "mandatory=..." option for rev-input to add * to label
 - Slower debounce, add it throughout
 - Task-button spinner, blue bg, disable while processing
-- Model hook loading spinner
 - Replace ad-hoc links with action/task/rev buttons
 
 - Sticker UX
@@ -42,10 +45,13 @@
   - Ditto for all routes, actually
 
 # Later:
+- Include "receiver" in sideloading of stickers index?
 - Loading categories in sticker index hook. Should we do that?
 - Show username for stickers when added to API
+- User stickers CORS/OPTIONS redirect bug
+  - Happens when using Ember data .get('stickers'), but not .query(...)
 
-- Handle offline case for stickers? (Do we need to change anything?)
+
 - Sticker deletion
 - "Sent stickers"?
 
@@ -61,6 +67,7 @@
 - Add "info" to routes, menu button
 - "Guest" author for notes
 - Rename 'user-validations' to 'validations' if need be
+
 
 # Style pass:
 - Design stickers

--- a/worklog.md
+++ b/worklog.md
@@ -1,7 +1,5 @@
 # Next Feature:
-- Prefetch strategy for relevant sticker requests?
-- "Offline" service https://tsubik.com/blog/make-your-emberjs-web-app-more-progressive-part-3-offline-data/
-  - Use offline service to prevent sticker sending
+- Test offline status change detection
 
 # Priority
 - Sticker export
@@ -17,7 +15,10 @@
 # Visual / UX:
 - Animations for routes, stickers
 - Model hook loading spinner
+- Ember-concurrency loading state after few ms
 - Menus
+  - Menu component
+  - Offline indicator
   - Flexbox
   - Color-code logged-in/out items
   - Log-in, log-out spot on menu
@@ -50,6 +51,7 @@
 - Show username for stickers when added to API
 - User stickers CORS/OPTIONS redirect bug
   - Happens when using Ember data .get('stickers'), but not .query(...)
+- Prefetch strategy for relevant sticker requests?
 
 
 - Sticker deletion
@@ -60,6 +62,7 @@
 - Sticker send validation second pass, e.g. "non empty string", "required"
 
 - Pagination? (Requires scrivener)
+  - Use that pagination in the sticker exploration
 
 - Note Card component
   - Note single view

--- a/worklog.md
+++ b/worklog.md
@@ -2,13 +2,13 @@
 - Sticker export
 
 # Priority
+- User stickers CORS/OPTIONS redirect bug
+  - Happens when using Ember data .get('stickers'), but not .query(...)
 - Note overhaul fields,
   - Note card interface overhaul
   - Import/Export notes
 - "Message of the day"
 - Reflection end-of-day functionality
-
-- Offline stickers
 - Admin sticker permissions
 - General UI/UX, JG
 - "Timeline view"
@@ -19,8 +19,9 @@
   - Color-code logged-in/out items
   - Log-in, log-out spot on menu
     - log-in task failure message
-  - Sticker send-received
-  - "mandatory=..." option for rev-input to add * to label
+  - Sticker send-received submenu
+
+- "mandatory=..." option for rev-input to add * to label
 - Slower debounce, add it throughout
 - Task-button spinner, blue bg, disable while processing
 - Model hook loading spinner

--- a/worklog.md
+++ b/worklog.md
@@ -1,15 +1,15 @@
 # Next Feature:
-- Test offline status change detection
+- UX / Visual
 
 # Priority
-- Sticker export
+- General UI/UX, JG
 - Note overhaul fields,
   - Note card interface overhaul
   - Import/Export notes
+- Sticker export
 - "Message of the day"
 - Reflection end-of-day functionality
 - Admin sticker permissions
-- General UI/UX, JG
 - "Timeline view"
 
 # Visual / UX:


### PR DESCRIPTION
This PR adds service worker fallback for sticker-related routes ("Network first" strategy).
A service that detects connectivity (based on the window.isOnline event) has been added, to enable features progressively, and notify the user of the functionality available.